### PR TITLE
Cloud agent bash restriction

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "deny": [
+      "Shell(bash)",
+      "Shell(sh)",
+      "Shell(zsh)",
+      "Shell(dash)",
+      "Shell(ksh)",
+      "Shell(/bin/bash)",
+      "Shell(/bin/sh)",
+      "Shell(/bin/zsh)"
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "type": "command",
+        "command": "python3 .cursor/hooks/restrict_shell_access.py"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/restrict_shell_access.py
+++ b/.cursor/hooks/restrict_shell_access.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shlex
+import sys
+
+
+BLOCKED_SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+
+
+def emit(permission, user_message=None, agent_message=None):
+    response = {"permission": permission}
+    if user_message:
+        response["userMessage"] = user_message
+    if agent_message:
+        response["agentMessage"] = agent_message
+
+    sys.stdout.write(json.dumps(response))
+
+
+def resolve_invoked_command(args):
+    if not args:
+        return "", ""
+
+    command = os.path.basename(args[0])
+    if command != "env":
+        return command, args[0]
+
+    for token in args[1:]:
+        if "=" in token and token.split("=", 1)[0].isidentifier():
+            continue
+        return os.path.basename(token), token
+
+    return command, args[0]
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        emit(
+            "deny",
+            "Shell command blocked because the policy payload was invalid.",
+            "The beforeShellExecution hook received invalid JSON. Do not retry until the hook is fixed.",
+        )
+        return 2
+
+    command = (payload.get("command") or "").strip()
+    if not command:
+        emit("allow")
+        return 0
+
+    try:
+        args = shlex.split(command, posix=True)
+    except ValueError:
+        emit(
+            "deny",
+            "Shell command blocked because it could not be parsed safely.",
+            "The proposed shell command could not be parsed safely by project policy.",
+        )
+        return 2
+
+    invoked_command, raw_command = resolve_invoked_command(args)
+    if invoked_command in BLOCKED_SHELLS:
+        emit(
+            "deny",
+            "Direct shell access is restricted for this project.",
+            f"Blocked shell invocation `{raw_command}` by project policy. Use approved non-shell tools or a permitted command instead.",
+        )
+        return 2
+
+    emit("allow")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restrict cloud agent access to bash and other common shell binaries to enhance security against prompt injection and unauthorized command execution.

<div><a href="https://cursor.com/agents/bc-b0815c1c-484f-4ebb-b8cf-26e403a88b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0815c1c-484f-4ebb-b8cf-26e403a88b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->